### PR TITLE
PsrMessage DTO for extended context handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,37 @@ $psrLogger->pushProcessor(function($record) {
 });
 ```
 
+You can use PsrMessage instead of regular string messages to add custom context.
+
+Standard usage:
+
+```php
+Yii::error(new \samdark\log\PsrMessage("Critical message", [
+    'custom' => 'context',
+    'key' => 'value',
+]));
+```
+
+Usage with PSR logger Levels:
+
+```php
+Yii::getLogger()->log(new \samdark\log\PsrMessage("Critical message", [
+    'important' => 'context'
+]), Psr\Log\LogLevel::CRITICAL);
+```
+
+Usage with PSR-3 log message processing:
+```php
+$psrLogger = new \Monolog\Logger('my_logger');
+$psrLogger->pushProcessor(new \Monolog\Processor\PsrLogMessageProcessor());
+```
+
+```php
+Yii::debug(new \samdark\log\PsrMessage("Greetings from {fruit}", [
+    'fruit' => 'banana'
+]));
+```
+
 ## Running tests
 
 In order to run tests perform the following commands:

--- a/src/PsrMessage.php
+++ b/src/PsrMessage.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace samdark\log;
+
+/**
+ * Class PsrMessage
+ * @package samdark\log
+ */
+final class PsrMessage
+{
+    /** @var string */
+    private $message;
+
+    /** @var array */
+    private $context = [];
+
+    public function __construct($message, $context = [])
+    {
+        $this->message = (string) $message;
+        $this->context = is_array($context) ? $context : [$context];
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return array
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+}

--- a/src/PsrMessage.php
+++ b/src/PsrMessage.php
@@ -38,4 +38,14 @@ final class PsrMessage
         return $this->context;
     }
 
+    /**
+     * PSR3 compatibility
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getMessage();
+    }
+
 }

--- a/src/PsrMessage.php
+++ b/src/PsrMessage.php
@@ -1,10 +1,11 @@
 <?php
 
-
 namespace samdark\log;
 
 /**
- * Class PsrMessage
+ * Data transfer object implementation for advanced PSR3 message and context handling
+ *
+ * @author Maksim Rodikov <maxrodikov@gmail.com>
  * @package samdark\log
  */
 final class PsrMessage

--- a/src/PsrTarget.php
+++ b/src/PsrTarget.php
@@ -109,6 +109,9 @@ class PsrTarget extends Target implements LoggerAwareInterface
                     } else {
                         $text = (string)$text;
                     }
+                } elseif ($text instanceof PsrMessage) {
+                    $context = array_merge($text->getContext(), $context); // Will not replace standard context keys
+                    $text = $text->getMessage();
                 } else {
                     $text = VarDumper::export($text);
                 }


### PR DESCRIPTION
PSRTarget is currently cast a logged message to a string, and there is no way to pass the context in any way since Yii does not intend to add the context to the message from outside.

The new DTO solves this problem by, on the one hand, adding the ability to transmit both message and additional context at the same time, and, on the other hand, leaving the ability to use itself for standard Yii log targets by implementing __toString method.

Usage example:

```php
$psrLogger = new \Monolog\Logger('my_logger');
$psrLogger->pushHandler(new \Monolog\Handler\SlackHandler('slack_token', 'logs', null, true, null, \Monolog\Logger::DEBUG));
$psrLogger->pushProcessor(new \Monolog\Processor\PsrLogMessageProcessor()); // PSR-3 message processing
```
Now we can add additional context to our messages (and use PSR-3 placeholders populated by our context data):

```php
Yii::error(new PsrMessage('Critical message', ['my' => 'context']));
Yii::getLogger()->log(new PsrMessage('Critical message from {process}', [
    'process' => 'BANANA',
    'other' => 'data',
]), Psr\Log\LogLevel::CRITICAL);
```